### PR TITLE
Allow multiple APK uploads #14

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -6,7 +6,7 @@ import assert from 'assert'
 
 var debug = Debug('playup')
 var publisher = androidpublisher('v2')
-var versionCodes = [];
+var versionCodes = []
 
 export default class Upload {
   constructor (client, apk, params = {track: 'alpha', obbs: [], recentChanges: {}}) {
@@ -81,8 +81,8 @@ export default class Upload {
 
   uploadAPK () {
     debug('> Uploading release')
-    const that = this;
-    const uploads = this.apk.map(function( apk ){
+    const that = this
+    const uploads = this.apk.map(function (apk) {
       return new Promise((done, rejectApk) => {
         publisher.edits.apks.upload({
           packageName: that.packageName,
@@ -93,14 +93,14 @@ export default class Upload {
             body: createReadStream(apk)
           }
         }, (err, upload) => {
-          if (err) return reject(err)
+          if (err) return rejectApk(err)
           debug('> Uploaded %s with version code %d and SHA1 %s', apk, upload.versionCode, upload.binary.sha1)
-          versionCodes.push(upload.versionCode);
+          versionCodes.push(upload.versionCode)
           done()
         })
-      });
-    });
-    return Promise.all(uploads);
+      })
+    })
+    return Promise.all(uploads)
   }
 
   uploadOBBs () {

--- a/src/upload.js
+++ b/src/upload.js
@@ -14,7 +14,8 @@ export default class Upload {
     assert(Upload.tracks.indexOf(params.track) !== -1, 'Unknown track')
 
     this.client = client
-    this.apk = apk
+
+    this.apk = typeof apk === 'string' ? [apk] : apk
     this.track = params.track
     this.obbs = params.obbs
     this.recentChanges = params.recentChanges
@@ -41,7 +42,7 @@ export default class Upload {
     debug('> Parsing manifest')
     // Wrapping in promise because apkParser throws in case of error
     return Promise.resolve().then(() => {
-      var reader = apkParser.readFile(this.apk)
+      var reader = apkParser.readFile(this.apk[0])
       var manifest = reader.readManifestSync()
       this.packageName = manifest.package
       this.versionCode = manifest.versionCode
@@ -79,8 +80,7 @@ export default class Upload {
 
   uploadAPK () {
     debug('> Uploading release')
-    let apks = typeof this.apk === 'string' ? [this.apk] : this.apk;
-    const uploads = apks.map(function( apk ){
+    const uploads = this.apk.map(function( apk ){
       return new Promise((done, rejectApk) => {
         publisher.edits.apks.upload({
           packageName: this.packageName,

--- a/src/upload.js
+++ b/src/upload.js
@@ -6,6 +6,7 @@ import assert from 'assert'
 
 var debug = Debug('playup')
 var publisher = androidpublisher('v2')
+var versionCodes = [];
 
 export default class Upload {
   constructor (client, apk, params = {track: 'alpha', obbs: [], recentChanges: {}}) {
@@ -80,12 +81,13 @@ export default class Upload {
 
   uploadAPK () {
     debug('> Uploading release')
+    const that = this;
     const uploads = this.apk.map(function( apk ){
       return new Promise((done, rejectApk) => {
         publisher.edits.apks.upload({
-          packageName: this.packageName,
-          editId: this.editId,
-          auth: this.client,
+          packageName: that.packageName,
+          editId: that.editId,
+          auth: that.client,
           media: {
             mimeType: 'application/vnd.android.package-archive',
             body: createReadStream(apk)
@@ -93,6 +95,7 @@ export default class Upload {
         }, (err, upload) => {
           if (err) return reject(err)
           debug('> Uploaded %s with version code %d and SHA1 %s', apk, upload.versionCode, upload.binary.sha1)
+          versionCodes.push(upload.versionCode);
           done()
         })
       });
@@ -140,7 +143,7 @@ export default class Upload {
         editId: this.editId,
         track: this.track,
         resource: {
-          versionCodes: [this.versionCode]
+          versionCodes: versionCodes
         },
         auth: this.client
       }, function (err, track) {

--- a/src/upload.js
+++ b/src/upload.js
@@ -79,21 +79,25 @@ export default class Upload {
 
   uploadAPK () {
     debug('> Uploading release')
-    return new Promise((done, reject) => {
-      publisher.edits.apks.upload({
-        packageName: this.packageName,
-        editId: this.editId,
-        auth: this.client,
-        media: {
-          mimeType: 'application/vnd.android.package-archive',
-          body: createReadStream(this.apk)
-        }
-      }, (err, upload) => {
-        if (err) return reject(err)
-        debug('> Uploaded %s with version code %d and SHA1 %s', this.apk, upload.versionCode, upload.binary.sha1)
-        done()
-      })
-    })
+    let apks = typeof this.apk === 'string' ? [this.apk] : this.apk;
+    const uploads = apks.map(function( apk ){
+      return new Promise((done, rejectApk) => {
+        publisher.edits.apks.upload({
+          packageName: this.packageName,
+          editId: this.editId,
+          auth: this.client,
+          media: {
+            mimeType: 'application/vnd.android.package-archive',
+            body: createReadStream(apk)
+          }
+        }, (err, upload) => {
+          if (err) return reject(err)
+          debug('> Uploaded %s with version code %d and SHA1 %s', apk, upload.versionCode, upload.binary.sha1)
+          done()
+        })
+      });
+    });
+    return Promise.all(uploads);
   }
 
   uploadOBBs () {

--- a/test/upload.js
+++ b/test/upload.js
@@ -10,7 +10,7 @@ var defaultPackage = 'com.jeduan.test'
 test('Upload should create with default options', function (t) {
   var up = new Upload(defaultClient, defaultApk)
   t.equals(up.client, defaultClient, 'Sets client correctly')
-  t.equals(up.apk, defaultApk, 'Sets apk correctly')
+  t.deepEquals(up.apk, [defaultApk], 'Sets apk correctly')
   t.equals(up.track, 'alpha', 'Sets track correctly')
   t.equals(up.obbs.length, 0, 'Sets obbs correctly')
   t.equals(Object.keys(up.recentChanges).length, 0, 'Sets recent changes correctly')


### PR DESCRIPTION
A couple of changes to allow an array of apks to be uploaded instead of just one. The multiple apks target different architectures. Fixes issue #14 