### PR TITLE
Add link to apkup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+_**This project is no longer maintained and [will stop working](https://github.com/jeduan/playup/issues/37) on December 1, 2019. Please use [apkup](https://www.npmjs.com/package/apkup) instead.**_
+
+<br>
+
 # playup [![Build Status][travis-image]][travis-url] [![Coverage Status][coveralls-image]][coveralls-url] [![npm][npm-image]][npm-url] [![js-standard-style][standard-image]][standard-url]
 
 [travis-image]: https://travis-ci.org/jeduan/playup.svg?branch=master
@@ -12,6 +16,7 @@
  > Upload APKs to Google Play
 
 This package offers a streamlined way to publish packages in the Google Play Store
+
 
 ## Install
 


### PR DESCRIPTION
I've added a link to apkup upon [@jeduan's suggestion](https://github.com/jeduan/playup/issues/37#issuecomment-511499430).

Since `playup` will actually stop working in December, when the Google Play Developer API v2 is deprecated, it might be a good idea to also mark the `playup` package as deprecated (and pointing to `apkup`) on NPM so that people can move to `apkup` _before_ it breaks. 

Feel free to edit the message or change where it is on the README. 